### PR TITLE
Add `pageAlign` arg to workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Then copy the contents of the `.txt` file to your GH secrets
 
 **Optional:** True to run `zipalign` on the `.apk` to perform the operation, rather than just verify zipalign.
 
+### `pageAlign`
+
+**Optional:** Whether to use the `-p` flag with `zipalign`, which page-aligns uncompressed .so files.
+
 ## ENV: `BUILD_TOOLS_VERSION`
 
 **Optional:** You can manually specify a version of build-tools to use. We use `32.0.0` by default.

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Actually zipalign the apk, rather than just verifying it'
     required: false
     default: 'false'
+  pageAlign:
+    description: 'Page-aligns uncompressed .so files'
+    required: false
+    default: 'true'
 outputs:
   signedReleaseFile:
     description: 'The signed release APK or AAB file, if single'

--- a/lib/main.js
+++ b/lib/main.js
@@ -54,6 +54,7 @@ function run() {
             const keyStorePassword = core.getInput('keyStorePassword', { required: true });
             const keyPassword = core.getInput('keyPassword');
             const zipAlign = core.getBooleanInput('zipAlign');
+            const pageAlign = core.getBooleanInput('pageAlign');
             console.log(`Preparing to sign key @ ${releaseDir} with signing key`);
             // 1. Find release files
             const releaseFiles = io.findReleaseFiles(releaseDir);
@@ -69,7 +70,7 @@ function run() {
                     const releaseFilePath = path_1.default.join(releaseDir, releaseFile.name);
                     let signedReleaseFile = '';
                     if (releaseFile.name.endsWith('.apk')) {
-                        signedReleaseFile = yield (0, signing_1.signApkFile)(releaseFilePath, signingKey, alias, keyStorePassword, keyPassword, zipAlign);
+                        signedReleaseFile = yield (0, signing_1.signApkFile)(releaseFilePath, signingKey, alias, keyStorePassword, keyPassword, zipAlign, pageAlign);
                     }
                     else if (releaseFile.name.endsWith('.aab')) {
                         signedReleaseFile = yield (0, signing_1.signAabFile)(releaseFilePath, signingKey, alias, keyStorePassword, keyPassword);

--- a/lib/signing.js
+++ b/lib/signing.js
@@ -38,7 +38,7 @@ const core = __importStar(require("@actions/core"));
 const io = __importStar(require("@actions/io"));
 const path = __importStar(require("path"));
 const fs = __importStar(require("fs"));
-function signApkFile(apkFile, signingKeyFile, alias, keyStorePassword, keyPassword, doZipAlign) {
+function signApkFile(apkFile, signingKeyFile, alias, keyStorePassword, keyPassword, doZipAlign, usePageAlign) {
     var _a;
     return __awaiter(this, void 0, void 0, function* () {
         core.debug("Zipaligning APK file");
@@ -55,12 +55,10 @@ function signApkFile(apkFile, signingKeyFile, alias, keyStorePassword, keyPasswo
         if (doZipAlign === true) {
             const unAlignedApk = apkFile + ".unaligned";
             fs.renameSync(apkFile, unAlignedApk);
-            yield exec.exec(`"${zipAlign}"`, [
-                '-v',
-                '4',
-                unAlignedApk,
-                apkFile
-            ]);
+            const zipAlignArgs = ['-v', '4', unAlignedApk, apkFile];
+            if (usePageAlign)
+                zipAlignArgs.unshift('-p');
+            yield exec.exec(`"${zipAlign}"`, zipAlignArgs);
         }
         // Verify alignment
         try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ async function run() {
     const keyStorePassword = core.getInput('keyStorePassword', { required: true });
     const keyPassword = core.getInput('keyPassword');
     const zipAlign = core.getBooleanInput('zipAlign')
+    const pageAlign = core.getBooleanInput('pageAlign')
 
     console.log(`Preparing to sign key @ ${releaseDir} with signing key`);
 
@@ -35,7 +36,7 @@ async function run() {
         const releaseFilePath = path.join(releaseDir, releaseFile.name);
         let signedReleaseFile = '';
         if (releaseFile.name.endsWith('.apk')) {
-          signedReleaseFile = await signApkFile(releaseFilePath, signingKey, alias, keyStorePassword, keyPassword, zipAlign);
+          signedReleaseFile = await signApkFile(releaseFilePath, signingKey, alias, keyStorePassword, keyPassword, zipAlign, pageAlign);
         } else if (releaseFile.name.endsWith('.aab')) {
           signedReleaseFile = await signAabFile(releaseFilePath, signingKey, alias, keyStorePassword, keyPassword);
         } else {

--- a/src/signing.ts
+++ b/src/signing.ts
@@ -10,7 +10,8 @@ export async function signApkFile(
     alias: string,
     keyStorePassword: string,
     keyPassword?: string,
-    doZipAlign?: boolean
+    doZipAlign?: boolean,
+    usePageAlign?: boolean
 ): Promise<string> {
 
     core.debug("Zipaligning APK file");
@@ -30,12 +31,9 @@ export async function signApkFile(
     if (doZipAlign === true) {
         const unAlignedApk = apkFile + ".unaligned";
         fs.renameSync(apkFile, unAlignedApk);
-        await exec.exec(`"${zipAlign}"`, [
-            '-v',
-            '4',
-            unAlignedApk,
-            apkFile
-        ]);
+        const zipAlignArgs = ['-v', '4', unAlignedApk, apkFile];
+        if (usePageAlign) zipAlignArgs.unshift('-p');
+        await exec.exec(`"${zipAlign}"`, zipAlignArgs);
     }
 
     // Verify alignment


### PR DESCRIPTION
This adds `pageAlign` as an [optional argument](https://developer.android.com/tools/zipalign#options) to zipalign using the `-p` flag.
Nowadays most apps require page-alignment when running with `zipalign` for the app to function properly.
After some testing, I could conclude `-c` alignment verification still succeeds when omitting `-p` as well.