### PR TITLE
Make `alias` optional for `apksigner`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Then copy the contents of the `.txt` file to your GH secrets
 
 ### `alias`
 
-**Required:** The alias of your signing key 
+**Optional:** The alias of your signing key  (note: if you're signing an `aab` file, this is still required.)
 
 ### `keyStorePassword`
 

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: true
   alias:
     description: 'The key alias'
-    required: true
+    required: false
   keyStorePassword:
     description: 'The password to the keystore'
     required: true

--- a/lib/main.js
+++ b/lib/main.js
@@ -50,7 +50,7 @@ function run() {
             }
             const releaseDir = core.getInput('releaseDirectory', { required: true });
             const signingKeyBase64 = core.getInput('signingKeyBase64', { required: true });
-            const alias = core.getInput('alias', { required: true });
+            const alias = core.getInput('alias', { required: false });
             const keyStorePassword = core.getInput('keyStorePassword', { required: true });
             const keyPassword = core.getInput('keyPassword');
             const zipAlign = core.getBooleanInput('zipAlign');

--- a/lib/signing.js
+++ b/lib/signing.js
@@ -84,10 +84,12 @@ function signApkFile(apkFile, signingKeyFile, alias, keyStorePassword, keyPasswo
         const args = [
             'sign',
             '--ks', signingKeyFile,
-            '--ks-key-alias', alias,
             '--ks-pass', `pass:${keyStorePassword}`,
             '--out', signedApkFile
         ];
+        if (alias) {
+            args.push('--ks-key-alias', alias);
+        }
         if (keyPassword) {
             args.push('--key-pass', `pass:${keyPassword}`);
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ async function run() {
 
     const releaseDir = core.getInput('releaseDirectory', { required: true });
     const signingKeyBase64 = core.getInput('signingKeyBase64', { required: true });
-    const alias = core.getInput('alias', { required: true });
+    const alias = core.getInput('alias', { required: false });
     const keyStorePassword = core.getInput('keyStorePassword', { required: true });
     const keyPassword = core.getInput('keyPassword');
     const zipAlign = core.getBooleanInput('zipAlign')

--- a/src/signing.ts
+++ b/src/signing.ts
@@ -63,10 +63,13 @@ export async function signApkFile(
     const args = [
         'sign',
         '--ks', signingKeyFile,
-        '--ks-key-alias', alias,
         '--ks-pass', `pass:${keyStorePassword}`,
         '--out', signedApkFile
     ];
+
+    if (alias) {
+        args.push('--ks-key-alias', alias);
+    }
 
     if (keyPassword) {
         args.push('--key-pass', `pass:${keyPassword}`);


### PR DESCRIPTION
Keep in mind, `jarsigner` still requires an alias which is being used here for signing `aab` files.
This was noted in the README.