### PR TITLE
All ncc output js files should have LF endings

### DIFF
--- a/lib/.gitattributes
+++ b/lib/.gitattributes
@@ -1,2 +1,2 @@
 # Make ncc output consistent
-*.js text=auto eol=lf
+*.js text eol=lf

--- a/lib/.gitattributes
+++ b/lib/.gitattributes
@@ -1,0 +1,2 @@
+# Make ncc output consistent
+*.js text=auto eol=lf


### PR DESCRIPTION
Idea from https://github.com/kevin-david/zipalign-sign-android-release/pull/18#issuecomment-2270325658