### PR TITLE
Bump SDK build tools version to 35

### DIFF
--- a/src/signing.ts
+++ b/src/signing.ts
@@ -16,7 +16,7 @@ export async function signApkFile(
     core.debug('Zipaligning APK file');
 
     // Find zipalign executable
-    const buildToolsVersion = process.env.BUILD_TOOLS_VERSION || '33.0.0';
+    const buildToolsVersion = process.env.BUILD_TOOLS_VERSION || '35.0.0';
     const androidHome = process.env.ANDROID_HOME;
     const buildTools = path.join(androidHome!, `build-tools/${buildToolsVersion}`);
     if (!fs.existsSync(buildTools)) {


### PR DESCRIPTION
The old `33` version no longer exists in the latest Ubuntu runner image, so the job just fails.